### PR TITLE
updated to a5_miseq 20150522

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Aaron Darling, aaron.darling@uts.edu.au
 RUN apt-get update -y
 RUN apt-get install -y openjdk-7-jre-headless file
 
-ADD http://downloads.sourceforge.net/project/ngopt/a5_miseq_linux_20141120.tar.gz /tmp/a5_miseq.tar.gz
+ADD http://downloads.sourceforge.net/project/ngopt/a5_miseq_linux_20150522.tar.gz /tmp/a5_miseq.tar.gz
 
 RUN mkdir /tmp/a5_miseq
 RUN tar xzf /tmp/a5_miseq.tar.gz --directory /tmp/a5_miseq --strip-components=1


### PR DESCRIPTION
Hi!

I updated the Dockerfile to download the latest version of a5. I needed this because the old version didn't think my Illumina headers were authentic.